### PR TITLE
Fix ADR-002 merge contract bugs and provenance gaps

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -74,13 +74,8 @@ class Settings(BaseSettings):
     CONSERVATIVE_ROUTING_ENABLED: bool = False
     # ADR-002 structural-first chunking (default remains recursive-only).
     ADAPTIVE_CHUNKING_ENABLED: bool = False
-    CHUNK_SIZE: int = Field(default=1000, ge=64)
-    CHUNK_OVERLAP: int = Field(default=200, ge=0)
-
-    # ADR-002 adaptive chunking (structural-first). Legacy recursive remains default.
-    ADAPTIVE_CHUNKING_ENABLED: bool = False
     ADAPTIVE_CHUNKING_ENABLE_SEMANTIC: bool = False
-    CHUNK_SIZE: int = Field(default=1000, ge=200)
+    CHUNK_SIZE: int = Field(default=1000, ge=64)
     CHUNK_OVERLAP: int = Field(default=200, ge=0)
 
     # Faithfulness controls

--- a/backend/graph_ingestion/adaptive_chunking.py
+++ b/backend/graph_ingestion/adaptive_chunking.py
@@ -21,6 +21,11 @@ _IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 _TABLE_SEPARATOR_RE = re.compile(r"^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$")
 
 
+def content_hash(text: str) -> str:
+    """SHA-256 digest of chunk text (used for idempotency checks)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
 @dataclass(frozen=True)
 class ChunkRecord:
     """Source-faithful chunk with provenance and policy metadata."""
@@ -46,11 +51,11 @@ class ChunkRecord:
     overlap: int | None = None
 
     def content_hash(self) -> str:
-        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+        return content_hash(self.text)
 
-    def to_metadata(self) -> dict[str, Any]:
+    def to_metadata(self, **extra: Any) -> dict[str, Any]:
         """Flat metadata suitable for Chroma / Neo4j property bags."""
-        payload = {
+        payload: dict[str, Any] = {
             "document_id": self.document_id,
             "chunk_index": self.ordinal,
             "chunk_type": self.chunk_type,
@@ -70,15 +75,24 @@ class ChunkRecord:
             "overlap": self.overlap if self.overlap is not None else -1,
             "chunk_hash": self.content_hash(),
         }
+        for key, value in extra.items():
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                payload[key] = value
         return payload
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
-def stable_chunk_id(text: str, ordinal: int) -> str:
-    """SHA-256-derived stable chunk ID (compatible with Path A IDs)."""
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+def stable_chunk_id(
+    text: str,
+    ordinal: int,
+    document_id: str,
+    policy_version: str = CHUNK_POLICY_VERSION,
+) -> str:
+    """SHA-256-derived stable chunk ID scoped to document + policy."""
+    payload = f"{document_id}|{policy_version}|{ordinal}|{text}"
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     return f"chunk_{ordinal}_{digest}"
 
 
@@ -113,7 +127,7 @@ def _make_record(
     return ChunkRecord(
         text=text,
         chunk_type=chunk_type,
-        chunk_id=stable_chunk_id(text, ordinal),
+        chunk_id=stable_chunk_id(text, ordinal, document_id),
         ordinal=ordinal,
         document_id=document_id,
         policy_version=CHUNK_POLICY_VERSION,
@@ -169,13 +183,19 @@ def _parse_blocks(text: str) -> list[dict[str, Any]]:
                 table_lines.append(lines[i])
                 i += 1
             headers = ""
+            separator = ""
+            body_rows = table_lines
             if len(table_lines) >= 2 and _TABLE_SEPARATOR_RE.match(table_lines[1].strip()):
                 headers = table_lines[0].strip()
+                separator = table_lines[1].strip()
+                body_rows = table_lines[2:]
             blocks.append(
                 {
                     "type": "table",
                     "text": "\n".join(table_lines).strip(),
                     "headers": headers,
+                    "separator": separator,
+                    "body_rows": body_rows,
                 }
             )
             continue
@@ -234,6 +254,56 @@ def _chunk_recursive_records(
             )
         )
     return records
+
+
+def _split_table_slices(
+    *,
+    headers: str,
+    separator: str,
+    body_rows: list[str],
+    full_text: str,
+    chunk_size: int,
+) -> list[str]:
+    """Slice oversized tables, repeating header/separator in each slice."""
+    if len(full_text) <= chunk_size:
+        return [full_text]
+
+    preface_parts = [part for part in (headers, separator) if part]
+    preface = "\n".join(preface_parts)
+    preface_len = len(preface) + (1 if preface else 0)
+
+    if not body_rows:
+        # No parseable body — fall back to recursive character split of full table.
+        return _recursive_split(full_text, chunk_size=chunk_size, chunk_overlap=0)
+
+    # If a single row plus header exceeds the budget, still emit it (cannot invent
+    # cell splits without losing table structure) but keep header repeated.
+    slices: list[str] = []
+    current_rows: list[str] = []
+    current_len = preface_len
+
+    def flush() -> None:
+        nonlocal current_rows, current_len
+        if not current_rows:
+            return
+        body = "\n".join(current_rows)
+        slices.append(f"{preface}\n{body}" if preface else body)
+        current_rows = []
+        current_len = preface_len
+
+    for row in body_rows:
+        row_cost = len(row) + (1 if current_rows else 0)
+        if current_rows and current_len + row_cost > chunk_size:
+            flush()
+            row_cost = len(row)
+        current_rows.append(row)
+        current_len += row_cost
+        # Extremely long single row: flush immediately so later rows can start fresh.
+        if current_len > chunk_size and len(current_rows) == 1:
+            flush()
+
+    flush()
+    return slices or [full_text]
 
 
 def _adaptive_chunk(
@@ -337,20 +407,32 @@ def _adaptive_chunk(
             path = current_path()
             table_text = str(block["text"])
             table_hash = hashlib.sha256(table_text.encode("utf-8")).hexdigest()[:16]
-            records.append(
-                _make_record(
-                    text=table_text,
-                    chunk_type="table",
-                    ordinal=ordinal,
-                    document_id=document_id,
-                    section_path=path,
-                    table_id=f"table_{table_hash}",
-                    headers=str(block.get("headers") or ""),
-                    caption="",
-                    boundary_reason="table_block",
-                )
+            table_id = f"table_{table_hash}"
+            headers = str(block.get("headers") or "")
+            slices = _split_table_slices(
+                headers=headers,
+                separator=str(block.get("separator") or ""),
+                body_rows=list(block.get("body_rows") or []),
+                full_text=table_text,
+                chunk_size=chunk_size,
             )
-            ordinal += 1
+            for slice_text in slices:
+                records.append(
+                    _make_record(
+                        text=slice_text,
+                        chunk_type="table",
+                        ordinal=ordinal,
+                        document_id=document_id,
+                        section_path=path,
+                        table_id=table_id,
+                        headers=headers,
+                        caption="",
+                        boundary_reason=(
+                            "table_block_sliced" if len(slices) > 1 else "table_block"
+                        ),
+                    )
+                )
+                ordinal += 1
             continue
 
         if btype == "image":

--- a/backend/graph_ingestion/ingest.py
+++ b/backend/graph_ingestion/ingest.py
@@ -1,42 +1,41 @@
+"""Idempotent PropertyGraph ingestion with ADR-002 chunk contracts."""
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
+from llama_index.core.indices.property_graph import PropertyGraphIndex
+from llama_index.core.schema import TextNode
 from neo4j import GraphDatabase
 
-from llama_index.core.schema import TextNode
-from llama_index.core.indices.property_graph import PropertyGraphIndex
-
 from backend.core.config import settings
-from backend.services.chroma_service import ChromaService
-from backend.graph_ingestion.adaptive_chunking import (
-    CHUNKING_POLICY_VERSION,
-    ChunkRecord,
-    build_validation_report,
-    chunk_document,
-    content_hash,
-)
-from backend.graph_ingestion.embedding_wrapper import LangChainEmbeddingWrapper
-from backend.graph_ingestion.stores import get_neo4j_graph_store, get_chroma_vector_store, get_llm
-from backend.graph_ingestion.schema import OntologySchema
-from backend.graph_ingestion.extractors import get_extractor_stack
-from backend.graph_ingestion.dedup import EntityResolver
-from backend.graph_ingestion.enrichment import NodeEnricher
 from backend.graph_ingestion.adaptive_chunking import (
     CHUNK_POLICY_VERSION,
     ChunkRecord,
     build_ingestion_validation_report,
     chunk_document,
+    content_hash,
+    stable_chunk_id,
 )
+from backend.graph_ingestion.dedup import EntityResolver
+from backend.graph_ingestion.embedding_wrapper import LangChainEmbeddingWrapper
+from backend.graph_ingestion.enrichment import NodeEnricher
+from backend.graph_ingestion.extractors import get_extractor_stack
+from backend.graph_ingestion.schema import OntologySchema
+from backend.graph_ingestion.stores import get_chroma_vector_store, get_llm, get_neo4j_graph_store
+from backend.services.chroma_service import ChromaService
 from backend.workers.document_processor import generate_document_id
 
 logger = logging.getLogger(__name__)
+
 
 class IdempotentGraphIngester:
     """
     Ingests files/folders into PropertyGraphIndex idempotently.
     Uses content hashing to skip already-ingested chunks and applies entity deduplication.
     """
+
     def __init__(self):
         self.chroma_service = ChromaService()
         self.embed_model = LangChainEmbeddingWrapper(self.chroma_service.embeddings)
@@ -45,11 +44,10 @@ class IdempotentGraphIngester:
         self.schema = OntologySchema("config/ontology_schema.yaml")
         self.llm = get_llm()
         self.resolver = EntityResolver(self.embed_model)
-        
-        # Initialize Neo4j driver directly for quick chunk existence checks
+
         self.neo4j_driver = GraphDatabase.driver(
             settings.NEO4J_URI,
-            auth=(settings.NEO4J_USER, settings.NEO4J_PASSWORD)
+            auth=(settings.NEO4J_USER, settings.NEO4J_PASSWORD),
         )
 
     def _enrich_ingested_nodes(self, nodes: List[TextNode]) -> Dict[str, Any]:
@@ -61,10 +59,12 @@ class IdempotentGraphIngester:
                 chroma_client=self.chroma_service.client,
             ).enrich(chunk_ids=chunk_ids)
             result["status"] = "success" if result["complete"] else "incomplete"
-            incomplete = []
+            incomplete: list[str] = []
             skipped = int(result.get("skipped_without_verified_context", 0) or 0)
             if skipped:
-                incomplete = [f"entity_without_verified_context:{idx}" for idx in range(skipped)]
+                incomplete = [
+                    f"entity_without_verified_context:{idx}" for idx in range(skipped)
+                ]
             missing_count = int(result.get("missing_vector_links", 0) or 0)
             verified_ids = chunk_ids if missing_count == 0 else []
             result["validation"] = build_ingestion_validation_report(
@@ -101,8 +101,6 @@ class IdempotentGraphIngester:
         """Check if a chunk with the given hash is already in the graph database."""
         try:
             with self.neo4j_driver.session() as session:
-                # LlamaIndex versions have used both labels; accept either so
-                # re-ingestion cannot silently duplicate a known chunk.
                 query = """
                     MATCH (n) WHERE (n:Chunk OR n:`__Chunk__`) AND n.chunk_hash = $hash
                     RETURN count(n) as count
@@ -114,7 +112,9 @@ class IdempotentGraphIngester:
             logger.error("Error checking chunk ingestion status in Neo4j: %s", e)
             return False
 
-    def chunk_text(self, text: str, chunk_size: int = 1000, chunk_overlap: int = 200) -> List[str]:
+    def chunk_text(
+        self, text: str, chunk_size: int = 1000, chunk_overlap: int = 200
+    ) -> List[str]:
         """Split text into overlapping chunks using the recursive fallback policy."""
         records = chunk_document(
             text,
@@ -140,23 +140,21 @@ class IdempotentGraphIngester:
             if adaptive_enabled is None
             else adaptive_enabled
         )
+        size = settings.CHUNK_SIZE if chunk_size is None else chunk_size
+        overlap = settings.CHUNK_OVERLAP if chunk_overlap is None else chunk_overlap
         if not enabled:
             # Preserve testability: callers/tests may patch chunk_text.
-            texts = self.chunk_text(
-                text,
-                chunk_size=settings.CHUNK_SIZE if chunk_size is None else chunk_size,
-                chunk_overlap=settings.CHUNK_OVERLAP if chunk_overlap is None else chunk_overlap,
-            )
+            texts = self.chunk_text(text, chunk_size=size, chunk_overlap=overlap)
             return [
                 ChunkRecord(
                     text=part,
                     chunk_type="recursive",
-                    chunk_id=f"chunk_{idx}_{self.compute_hash(part)}",
+                    chunk_id=stable_chunk_id(part, idx, document_id),
                     ordinal=idx,
                     document_id=document_id,
                     policy_version=CHUNK_POLICY_VERSION,
                     tokenizer_version="recursive-character-v1",
-                    overlap=settings.CHUNK_OVERLAP if chunk_overlap is None else chunk_overlap,
+                    overlap=overlap,
                     boundary_reason="unstructured_text",
                 )
                 for idx, part in enumerate(texts)
@@ -165,8 +163,8 @@ class IdempotentGraphIngester:
             text,
             document_id=document_id,
             adaptive_enabled=True,
-            chunk_size=settings.CHUNK_SIZE if chunk_size is None else chunk_size,
-            chunk_overlap=settings.CHUNK_OVERLAP if chunk_overlap is None else chunk_overlap,
+            chunk_size=size,
+            chunk_overlap=overlap,
         )
 
     def chunk_records(
@@ -177,24 +175,12 @@ class IdempotentGraphIngester:
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
     ) -> List[ChunkRecord]:
-        """Build ADR-002 chunk records (structural-first when enabled)."""
-        size = chunk_size if chunk_size is not None else settings.CHUNK_SIZE
-        overlap = chunk_overlap if chunk_overlap is not None else settings.CHUNK_OVERLAP
-        policy = (
-            "structural_first"
-            if settings.ADAPTIVE_CHUNKING_ENABLED
-            else "recursive_only"
-        )
-        return chunk_document(
+        """Alias for build_chunks (structural-first when adaptive flag is on)."""
+        return self.build_chunks(
             text,
             document_id=document_id,
-            chunk_size=size,
-            chunk_overlap=overlap,
-            policy=policy,
-            enable_semantic=bool(
-                settings.ADAPTIVE_CHUNKING_ENABLED
-                and settings.ADAPTIVE_CHUNKING_ENABLE_SEMANTIC
-            ),
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
         )
 
     def _nodes_from_records(
@@ -210,14 +196,18 @@ class IdempotentGraphIngester:
         skipped_chunks = 0
         total = len(records)
         for record in records:
-            chunk_hash = record.chunk_hash or self.compute_hash(record.text)
-            if self.is_chunk_ingested(chunk_hash):
+            chunk_digest = record.content_hash()
+            if self.is_chunk_ingested(chunk_digest):
                 skipped_chunks += 1
                 continue
             node_meta = record.to_metadata(
                 file_name=file_name,
                 total_chunks=total,
-                **metadata,
+                **{
+                    key: value
+                    for key, value in metadata.items()
+                    if isinstance(value, (str, int, float, bool)) or value is None
+                },
             )
             node = TextNode(
                 text=record.text,
@@ -228,56 +218,50 @@ class IdempotentGraphIngester:
             accepted.append(record)
         return nodes_to_ingest, skipped_chunks, accepted
 
-    def ingest_file(self, file_path: str, metadata: Dict[str, Any] = None) -> Dict[str, Any]:
+    def ingest_file(
+        self, file_path: str, metadata: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
         """
         Ingests a single file (PDF or Markdown/text) into the PropertyGraphIndex.
         Returns a summary dictionary of what was ingested.
         """
         if metadata is None:
             metadata = {}
-            
+
         file_path_obj = Path(file_path)
         if not file_path_obj.exists():
             raise FileNotFoundError(f"File not found: {file_path}")
-            
-        # 1. Read file content
+
         content = ""
         if file_path_obj.suffix.lower() == ".pdf":
             from backend.workers.document_processor import extract_text_from_pdf
+
             content = extract_text_from_pdf(file_path)
         else:
-            with open(file_path, "r", encoding="utf-8") as f:
-                content = f.read()
-                
+            with open(file_path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+
         if not content.strip():
             logger.warning("Empty file skipped: %s", file_path)
             return {"status": "skipped", "reason": "empty content"}
 
         doc_id = generate_document_id(file_path)
         records = self.build_chunks(content, document_id=doc_id)
-        nodes_to_ingest = []
-        skipped_chunks = 0
-
-        for record in records:
-            chunk_hash = record.content_hash()
-            if self.is_chunk_ingested(chunk_hash):
-                skipped_chunks += 1
-                continue
-                
-            node_meta = {
-                "file_name": file_path_obj.name,
-                "total_chunks": len(records),
-                **record.to_metadata(),
-                **metadata,
-            }
-            node = TextNode(text=record.text, metadata=node_meta, id_=record.chunk_id)
-            nodes_to_ingest.append(node)
+        nodes_to_ingest, skipped_chunks, accepted = self._nodes_from_records(
+            records,
+            file_name=file_path_obj.name,
+            metadata=metadata,
+        )
 
         if not nodes_to_ingest:
-            logger.info("All %d chunks for file '%s' already ingested.", len(records), file_path_obj.name)
+            logger.info(
+                "All %d chunks for file '%s' already ingested.",
+                len(records),
+                file_path_obj.name,
+            )
             return {
                 "file_name": file_path_obj.name,
-                "document_id": document_id,
+                "document_id": doc_id,
                 "status": "skipped",
                 "total_chunks": len(records),
                 "skipped_chunks": skipped_chunks,
@@ -287,14 +271,12 @@ class IdempotentGraphIngester:
 
         logger.info(
             "Ingesting %d / %d chunks for file '%s'...",
-            len(nodes_to_ingest), len(records), file_path_obj.name
+            len(nodes_to_ingest),
+            len(records),
+            file_path_obj.name,
         )
 
-        # 3. Extract and resolve entities using PropertyGraphIndex pipeline
         extractors = get_extractor_stack(self.schema, self.llm, self.resolver)
-
-        # 4. Build/Update PropertyGraphIndex
-        # LlamaIndex writes nodes to the graph store and vector store
         PropertyGraphIndex(
             nodes=nodes_to_ingest,
             property_graph_store=self.graph_store,
@@ -302,25 +284,32 @@ class IdempotentGraphIngester:
             embed_model=self.embed_model,
             llm=self.llm,
             kg_extractors=extractors,
-            show_progress=True
+            show_progress=True,
         )
 
         enrichment = self._enrich_ingested_nodes(nodes_to_ingest)
-        validation = build_validation_report(accepted, enrichment=enrichment)
+        validation = enrichment.get("validation") or build_ingestion_validation_report(
+            chunk_ids=[node.node_id for node in nodes_to_ingest],
+            verified_chunk_ids=[],
+            incomplete_entity_ids=["validation_missing"],
+        )
 
         return {
             "file_name": file_path_obj.name,
-            "status": "success",
+            "document_id": doc_id,
+            "status": "success" if validation.get("complete") else "incomplete",
             "total_chunks": len(records),
             "skipped_chunks": skipped_chunks,
-            "ingested_chunks": len(nodes_to_ingest),
+            "ingested_chunks": len(accepted),
             "chunk_policy_version": CHUNK_POLICY_VERSION,
             "adaptive_chunking": settings.ADAPTIVE_CHUNKING_ENABLED,
             "enrichment": enrichment,
-            "ingestion_validation": validation.to_dict(),
+            "ingestion_validation": validation,
         }
 
-    def ingest_directory(self, dir_path: str, metadata: Dict[str, Any] = None) -> List[Dict[str, Any]]:
+    def ingest_directory(
+        self, dir_path: str, metadata: Dict[str, Any] | None = None
+    ) -> List[Dict[str, Any]]:
         """
         Ingests all supported files from a directory in a single batch to avoid
         event loop deadlocks and enable global entity resolution.
@@ -328,76 +317,68 @@ class IdempotentGraphIngester:
         dir_path_obj = Path(dir_path)
         if not dir_path_obj.is_dir():
             raise NotADirectoryError(f"Not a directory: {dir_path}")
-            
+
         if metadata is None:
             metadata = {}
 
-        all_nodes_to_ingest = []
+        all_nodes_to_ingest: List[TextNode] = []
         all_accepted: List[ChunkRecord] = []
         skipped_chunks = 0
         total_chunks = 0
-        file_summaries = []
+        file_summaries: List[Dict[str, Any]] = []
 
-        from backend.workers.document_processor import generate_document_id
-
-        # 1. Collect and chunk all files, checking content hashes
         for file_path in dir_path_obj.iterdir():
             if file_path.suffix.lower() not in [".pdf", ".md", ".txt"]:
                 continue
-                
+
             content = ""
             if file_path.suffix.lower() == ".pdf":
                 from backend.workers.document_processor import extract_text_from_pdf
+
                 content = extract_text_from_pdf(str(file_path))
             else:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-                    
+                with open(file_path, "r", encoding="utf-8") as handle:
+                    content = handle.read()
+
             if not content.strip():
                 continue
-                
+
             doc_id = generate_document_id(str(file_path))
             records = self.build_chunks(content, document_id=doc_id)
             total_chunks += len(records)
-            file_nodes = []
-            
-            for record in records:
-                chunk_hash = record.content_hash()
-                if self.is_chunk_ingested(chunk_hash):
-                    skipped_chunks += 1
-                    continue
-                    
-                node_meta = {
-                    "file_name": file_path.name,
-                    "total_chunks": len(records),
-                    **record.to_metadata(),
-                    **metadata,
-                }
-                node = TextNode(text=record.text, metadata=node_meta, id_=record.chunk_id)
-                file_nodes.append(node)
-                
+            file_nodes, file_skipped, accepted = self._nodes_from_records(
+                records,
+                file_name=file_path.name,
+                metadata=metadata,
+            )
+            skipped_chunks += file_skipped
+
             if file_nodes:
                 all_nodes_to_ingest.extend(file_nodes)
                 all_accepted.extend(accepted)
-                file_summaries.append({
-                    "file_name": file_path.name,
-                    "document_id": document_id,
-                    "status": "pending_ingestion",
-                    "total_chunks": len(records),
-                    "skipped_chunks": skipped_chunks,
-                    "ingested_chunks": len(file_nodes),
-                    "chunk_policy_version": CHUNK_POLICY_VERSION,
-                })
+                file_summaries.append(
+                    {
+                        "file_name": file_path.name,
+                        "document_id": doc_id,
+                        "status": "pending_ingestion",
+                        "total_chunks": len(records),
+                        "skipped_chunks": file_skipped,
+                        "ingested_chunks": len(file_nodes),
+                        "chunk_policy_version": CHUNK_POLICY_VERSION,
+                    }
+                )
             else:
-                file_summaries.append({
-                    "file_name": file_path.name,
-                    "document_id": document_id,
-                    "status": "skipped",
-                    "total_chunks": len(records),
-                    "skipped_chunks": len(records),
-                    "ingested_chunks": 0,
-                    "chunk_policy_version": CHUNK_POLICY_VERSION,
-                })
+                file_summaries.append(
+                    {
+                        "file_name": file_path.name,
+                        "document_id": doc_id,
+                        "status": "skipped",
+                        "total_chunks": len(records),
+                        "skipped_chunks": len(records),
+                        "ingested_chunks": 0,
+                        "chunk_policy_version": CHUNK_POLICY_VERSION,
+                    }
+                )
 
         if not all_nodes_to_ingest:
             logger.info("All files in directory already ingested.")
@@ -405,14 +386,12 @@ class IdempotentGraphIngester:
 
         logger.info(
             "Batch ingesting %d / %d chunks from %d files...",
-            len(all_nodes_to_ingest), total_chunks, len(file_summaries)
+            len(all_nodes_to_ingest),
+            total_chunks,
+            len(file_summaries),
         )
 
-        # 2. Extract entities and relationships
-        # 2. Extract and resolve entities using PropertyGraphIndex pipeline
         extractors = get_extractor_stack(self.schema, self.llm, self.resolver)
-
-        # 3. Write to index (ONE SINGLE CALL)
         PropertyGraphIndex(
             nodes=all_nodes_to_ingest,
             property_graph_store=self.graph_store,
@@ -420,22 +399,23 @@ class IdempotentGraphIngester:
             embed_model=self.embed_model,
             llm=self.llm,
             kg_extractors=extractors,
-            show_progress=True
+            show_progress=True,
         )
 
         enrichment = self._enrich_ingested_nodes(all_nodes_to_ingest)
-        validation = build_validation_report(all_accepted, enrichment=enrichment)
+        validation = enrichment.get("validation") or build_ingestion_validation_report(
+            chunk_ids=[node.node_id for node in all_nodes_to_ingest],
+            verified_chunk_ids=[],
+            incomplete_entity_ids=["validation_missing"],
+        )
 
-        # Update statuses in summary
-        for f in file_summaries:
-            if f["status"] == "pending_ingestion":
-                f["status"] = "success" if validation.complete else "incomplete"
-                f["enrichment"] = enrichment
-                f["ingestion_validation"] = validation.to_dict()
-                f["chunking_policy_version"] = (
-                    CHUNKING_POLICY_VERSION
-                    if settings.ADAPTIVE_CHUNKING_ENABLED
-                    else "legacy.recursive"
+        for summary in file_summaries:
+            if summary["status"] == "pending_ingestion":
+                summary["status"] = (
+                    "success" if validation.get("complete") else "incomplete"
                 )
+                summary["enrichment"] = enrichment
+                summary["ingestion_validation"] = validation
+                summary["chunk_policy_version"] = CHUNK_POLICY_VERSION
 
         return file_summaries

--- a/backend/services/neo4j_service.py
+++ b/backend/services/neo4j_service.py
@@ -199,14 +199,19 @@ class Neo4jService:
                         for chunk_id, chunk in zip(chunk_ids, chunks)
                     ])
                 
-                # Create entity nodes and link to document
+                # Create entity nodes and link to document.
+                # Chunk MENTIONS require a textual match — never invent locality.
+                incomplete_entity_ids: list[str] = []
+                linked_entity_ids: list[str] = []
                 for entity in entities:
                     matching_chunk_ids = [
                         chunk_id for chunk_id, chunk in zip(chunk_ids, chunks)
                         if entity["name"].lower() in chunk.lower()
                     ]
-                    if not matching_chunk_ids and chunk_ids:
-                        matching_chunk_ids = [chunk_ids[0]]
+                    if matching_chunk_ids:
+                        linked_entity_ids.append(entity["name"])
+                    else:
+                        incomplete_entity_ids.append(entity["name"])
                     session.run("""
                         MERGE (e:Entity {name: $name, type: $type})
                         WITH e
@@ -233,16 +238,21 @@ class Neo4jService:
                     """, source=rel['source'], target=rel['target'], rel_type=rel['type'],
                          evidence_text=evidence, weight=float(rel.get("weight", 0.75)))
 
-            enrichment_result = None
+            enrichment_result: Dict[str, Any] = {
+                "incomplete_entity_ids": incomplete_entity_ids,
+                "linked_entity_ids": linked_entity_ids,
+            }
             if chunk_ids:
                 from backend.graph_ingestion.enrichment import NodeEnricher
                 from backend.services.chroma_service import ChromaService
 
                 chroma = ChromaService()
                 try:
-                    enrichment_result = NodeEnricher(
+                    node_enrichment = NodeEnricher(
                         self.driver, chroma.client
                     ).enrich(chunk_ids=chunk_ids)
+                    if isinstance(node_enrichment, dict):
+                        enrichment_result = {**node_enrichment, **enrichment_result}
                 finally:
                     chroma.close()
             return GraphWriteResult(success=True, enrichment=enrichment_result)

--- a/backend/workers/tasks.py
+++ b/backend/workers/tasks.py
@@ -54,7 +54,7 @@ async def _persist_document(
     chunk_metadata: list[Dict[str, Any]],
     chunk_ids: list[str],
     metadata: Dict[str, Any],
-) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
+) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]], Any]:
     """Run all async ingestion work in one event loop and close every client."""
     chroma = ChromaService()
     neo4j = None
@@ -119,9 +119,11 @@ async def _persist_document(
             chunk_ids=chunk_ids,
         )
         if not graph_write:
-            raise RuntimeError("Failed to store document in Neo4j")
+            raise RuntimeError(
+                f"Failed to store document in Neo4j: {getattr(graph_write, 'error', None)}"
+            )
         logger.info("[Task %s] Stored in Neo4j", task.request.id)
-        return entities, relationships
+        return entities, relationships, graph_write
     finally:
         if neo4j is not None:
             neo4j.close()
@@ -192,7 +194,7 @@ def process_document(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str
             }
             chunk_metadata.append(chunk_meta)
         
-        entities, relationships = asyncio.run(_persist_document(
+        entities, relationships, graph_write = asyncio.run(_persist_document(
             self,
             doc_id=doc_id,
             file_name=file_name,
@@ -214,12 +216,23 @@ def process_document(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str
                 file_path,
                 e,
             )
-        
+
+        enrichment = getattr(graph_write, "enrichment", None) or {}
+        incomplete_entity_ids = list(enrichment.get("incomplete_entity_ids") or [])
+        linked_entity_ids = list(enrichment.get("linked_entity_ids") or [])
+        missing_vector_links = int(enrichment.get("missing_vector_links", 0) or 0)
+        verified_chunk_ids = chunk_ids if missing_vector_links == 0 else []
+        if enrichment.get("skipped_without_verified_context"):
+            skipped = int(enrichment["skipped_without_verified_context"])
+            incomplete_entity_ids.extend(
+                f"entity_without_verified_context:{idx}" for idx in range(skipped)
+            )
+
         validation = build_ingestion_validation_report(
             chunk_ids=chunk_ids,
-            verified_chunk_ids=chunk_ids,
-            enriched_entity_ids=[e.get("name") for e in entities if e.get("name")],
-            incomplete_entity_ids=[],
+            verified_chunk_ids=verified_chunk_ids,
+            enriched_entity_ids=linked_entity_ids,
+            incomplete_entity_ids=incomplete_entity_ids,
         )
 
         # Return results
@@ -233,8 +246,9 @@ def process_document(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str
             "adaptive_chunking": bool(
                 metadata.get("adaptive_chunking", settings.ADAPTIVE_CHUNKING_ENABLED)
             ),
+            "enrichment": enrichment,
             "validation": validation,
-            "status": "success"
+            "status": "success" if validation.get("complete") else "incomplete",
         }
         
     except Exception as e:

--- a/tests/test_adaptive_chunking.py
+++ b/tests/test_adaptive_chunking.py
@@ -138,3 +138,34 @@ def test_validation_report_is_additive_and_reports_incomplete_links():
     assert report["policy_version"] == CHUNK_POLICY_VERSION
     # Additive: callers can merge without inventing context.
     assert "invented" not in str(report).lower()
+
+
+def test_chunk_ids_differ_across_documents_with_identical_text():
+    text = "Shared paragraph about Kinetic-V retrieval."
+    a = chunk_document(text, document_id="doc-a", adaptive_enabled=False, chunk_size=200)
+    b = chunk_document(text, document_id="doc-b", adaptive_enabled=False, chunk_size=200)
+    assert a and b
+    assert [c.text for c in a] == [c.text for c in b]
+    assert [c.chunk_id for c in a] != [c.chunk_id for c in b]
+    assert all(c.document_id == "doc-a" for c in a)
+    assert all(c.document_id == "doc-b" for c in b)
+
+
+def test_oversized_table_is_sliced_with_repeated_headers():
+    header = "| ColA | ColB |"
+    separator = "| --- | --- |"
+    rows = [f"| value-{i} | detail-{i}-{'x' * 20} |" for i in range(40)]
+    table = "\n".join([header, separator, *rows])
+    chunks = chunk_document(
+        f"# Tables\n\n{table}",
+        document_id="doc_table",
+        adaptive_enabled=True,
+        chunk_size=120,
+        chunk_overlap=0,
+    )
+    tables = [c for c in chunks if c.chunk_type == "table"]
+    assert len(tables) > 1, "oversized table must be sliced"
+    assert all(len(c.text) <= 120 for c in tables)
+    assert all(header in c.text for c in tables)
+    assert all(c.headers and "ColA" in c.headers for c in tables)
+    assert len({c.table_id for c in tables}) == 1

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -177,11 +177,51 @@ def test_legacy_document_ingestion_creates_chunks_and_runs_enrichment():
         ))
 
     assert result.success is True
-    assert result.enrichment == enrichment
+    assert result.enrichment["enriched"] == 1
+    assert result.enrichment["incomplete_entity_ids"] == []
+    assert result.enrichment["linked_entity_ids"] == ["Neo4j"]
     assert any("MERGE (c:__Node__:Chunk" in call.args[0] for call in session.run.call_args_list)
     enricher_cls.return_value.enrich.assert_called_once_with(chunk_ids=["chunk-1"])
     assert chroma_cls.called
     chroma_cls.return_value.close.assert_called_once_with()
+
+
+def test_entity_without_chunk_match_is_not_linked_to_first_chunk():
+    """ADR-002: never invent evidence locality for unmatched entities."""
+    service = Neo4jService.__new__(Neo4jService)
+    session = MagicMock()
+    service.driver = MagicMock()
+    service.driver.session.return_value.__enter__.return_value = session
+
+    with patch("backend.services.chroma_service.ChromaService"), patch(
+        "backend.graph_ingestion.enrichment.NodeEnricher"
+    ) as enricher_cls:
+        enricher_cls.return_value.enrich.return_value = {
+            "enriched": 0,
+            "complete": False,
+            "skipped_without_verified_context": 1,
+        }
+        result = asyncio.run(service.add_document_graph(
+            doc_id="doc-2",
+            content="Only talks about Alpha.",
+            metadata={"file_name": "test.md"},
+            entities=[{"name": "UnmentionedEntity", "type": "Concept"}],
+            relationships=[],
+            chunks=["Only talks about Alpha."],
+            chunk_ids=["chunk-alpha"],
+        ))
+
+    assert result.success is True
+    assert "UnmentionedEntity" in result.enrichment["incomplete_entity_ids"]
+    assert result.enrichment["linked_entity_ids"] == []
+
+    entity_calls = [
+        call for call in session.run.call_args_list
+        if "MERGE (e:Entity" in call.args[0]
+    ]
+    assert len(entity_calls) == 1
+    # Document MENTIONS still allowed; chunk MENTIONS must not invent chunk-alpha.
+    assert entity_calls[0].kwargs["chunk_ids"] == []
 
 
 def test_legacy_relationship_upsert_uses_valid_merge_clause_order():

--- a/tests/test_ingest_idempotency.py
+++ b/tests/test_ingest_idempotency.py
@@ -1,20 +1,25 @@
 from backend.graph_ingestion.ingest import IdempotentGraphIngester
-from backend.graph_ingestion.adaptive_chunking import ChunkRecord, content_hash
-from llama_index.core.schema import TextNode
+from backend.graph_ingestion.adaptive_chunking import (
+    CHUNK_POLICY_VERSION,
+    ChunkRecord,
+    content_hash,
+    stable_chunk_id,
+)
 from unittest.mock import MagicMock, patch
-import pytest
 
 
 def _record(text: str = "test chunk content", document_id: str = "doc_test") -> ChunkRecord:
     digest = content_hash(text)
     return ChunkRecord(
-        chunk_id=f"chunk_{digest}",
+        chunk_id=stable_chunk_id(text, 0, document_id),
         text=text,
         chunk_type="recursive",
         document_id=document_id,
         ordinal=0,
-        chunk_hash=digest,
-        boundary_reason="unstructured_fallback",
+        policy_version=CHUNK_POLICY_VERSION,
+        boundary_reason="unstructured_text",
+        tokenizer_version="recursive-character-v1",
+        overlap=200,
     )
 
 
@@ -36,7 +41,7 @@ def test_ingest_idempotency_skip(mock_get_llm, mock_get_chroma_store, mock_get_n
     # Instantiate ingester
     ingester = IdempotentGraphIngester()
 
-    with patch.object(IdempotentGraphIngester, "chunk_records", return_value=[_record()]):
+    with patch.object(IdempotentGraphIngester, "build_chunks", return_value=[_record()]):
         # Run ingestion
         res = ingester.ingest_file("tests/test_schema.py")
 
@@ -45,11 +50,13 @@ def test_ingest_idempotency_skip(mock_get_llm, mock_get_chroma_store, mock_get_n
         assert res["total_chunks"] == 1
         assert res["skipped_chunks"] == 1
         assert res["ingested_chunks"] == 0
+        assert res["document_id"].startswith("doc_")
 
         # Check that query was called
         mock_session.run.assert_called_once()
 
     ingester.close()
+
 
 @patch("backend.graph_ingestion.ingest.GraphDatabase.driver")
 @patch("backend.graph_ingestion.ingest.ChromaService")
@@ -75,13 +82,13 @@ def test_ingest_idempotency_ingest(mock_node_enricher, mock_get_extractors, mock
     mock_get_extractors.return_value = [mock_extractor]
     mock_node_enricher.return_value.enrich.return_value = {
         "enriched": 1, "verified_vector_links": 1, "missing_vector_links": 0,
-        "complete": True,
+        "complete": True, "skipped_without_verified_context": 0,
     }
 
     # Instantiate ingester
     ingester = IdempotentGraphIngester()
 
-    with patch.object(IdempotentGraphIngester, "chunk_records", return_value=[_record()]):
+    with patch.object(IdempotentGraphIngester, "build_chunks", return_value=[_record()]):
         # Run ingestion
         res = ingester.ingest_file("tests/test_schema.py")
 
@@ -93,6 +100,8 @@ def test_ingest_idempotency_ingest(mock_node_enricher, mock_get_extractors, mock
         assert res["enrichment"]["verified_vector_links"] == 1
         assert res["enrichment"]["status"] == "success"
         assert "ingestion_validation" in res
+        assert res["ingestion_validation"]["complete"] is True
+        assert res["document_id"].startswith("doc_")
 
         # Verify PropertyGraphIndex was built with a stable chunk id
         mock_property_graph_index.assert_called_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Addresses production-review findings against the merged ADR-002 adaptive chunking work.

- **Critical:** Rebuild [`ingest.py`](backend/graph_ingestion/ingest.py) onto the real adaptive-chunking contract (`CHUNK_POLICY_VERSION`, `content_hash()`, `build_ingestion_validation_report`, `to_metadata(**extra)`), and remove undefined `document_id` / `accepted` references.
- **High:** Scope `stable_chunk_id()` by `document_id` + policy version so identical text across documents no longer collides in Chroma.
- **High:** Slice oversized tables under `chunk_size`, repeating header/separator in each slice.
- **High:** Celery validation now consumes `GraphWriteResult.enrichment`; Neo4j no longer invents first-chunk `MENTIONS` for unmatched entities (reports `incomplete_entity_ids` instead).

## Test plan
- [x] `pytest tests/test_adaptive_chunking.py`
- [x] `pytest tests/test_ingest_idempotency.py`
- [x] Neo4j locality + enrichment contract tests in `tests/test_enrichment.py`
- [x] `pytest tests/test_warning_hardening.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f42c56d-ca87-4cac-83be-88e35c8327fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f42c56d-ca87-4cac-83be-88e35c8327fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

